### PR TITLE
implement mini basket widget with local-storage sync

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,2 +1,3 @@
 <app-cursor></app-cursor>
 <router-outlet></router-outlet>
+<app-mini-basket></app-mini-basket>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,10 +1,11 @@
 import { Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
 import { CursorComponent } from './components/sections/cursor/cursor.component';
+import { MiniBasketComponent } from './components/sections/mini-basket/mini-basket.component';
 
 @Component({
   selector: 'app-root',
-  imports: [RouterOutlet, CursorComponent],
+  imports: [RouterOutlet, CursorComponent, MiniBasketComponent],
   templateUrl: './app.component.html',
   styleUrl: './app.component.css'
 })

--- a/src/app/components/pages/checkout/checkout.component.css
+++ b/src/app/components/pages/checkout/checkout.component.css
@@ -233,6 +233,51 @@ input.error {
   gap: 8px;
 }
 
+.quantity-controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.qty-btn {
+  width: 24px;
+  height: 24px;
+  border: 1px solid #444;
+  background: #333;
+  color: #fff;
+  border-radius: 4px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 14px;
+  font-weight: 600;
+  transition: all 0.2s ease;
+}
+
+.qty-btn:hover {
+  background: #444;
+  border-color: #555;
+}
+
+.qty-btn.minus:hover {
+  background: #ff4757;
+  border-color: #ff4757;
+}
+
+.qty-btn.plus:hover {
+  background: #2ed573;
+  border-color: #2ed573;
+}
+
+.quantity {
+  font-size: 14px;
+  font-weight: 600;
+  min-width: 20px;
+  text-align: center;
+  color: #e3e3e3;
+}
+
 .item-price {
   font-size: 20px;
   color: #e3e3e3;

--- a/src/app/components/pages/checkout/checkout.component.html
+++ b/src/app/components/pages/checkout/checkout.component.html
@@ -180,16 +180,21 @@
         <div class="summary-items" *ngIf="orderSummary.length > 0">
           <div class="cart-actions" *ngIf="orderSummary.length > 0">
             <button class="clear-cart-btn" (click)="clearCartStorage()">Clear Cart</button>
-          </div>
-          <div class="summary-item" *ngFor="let item of orderSummary">
+          </div>          <div class="summary-item" *ngFor="let item of orderSummary">
             <div class="item-info">
               <h3>{{ item.title }}</h3>
               <p class="package-name">{{ item.package }}</p>
               <ul class="features-list">
                 <li *ngFor="let feature of item.features">{{ feature }}</li>
               </ul>
-            </div>            <div class="item-actions">
-              <div class="item-price">${{ item.price }}</div>
+            </div>
+            <div class="item-actions">
+              <div class="quantity-controls">
+                <button class="qty-btn minus" (click)="decreaseQuantity(item)">-</button>
+                <span class="quantity">{{item.quantity || 1}}</span>
+                <button class="qty-btn plus" (click)="increaseQuantity(item)">+</button>
+              </div>
+              <div class="item-price">${{ (item.price * (item.quantity || 1)).toFixed(2) }}</div>
               <button class="remove-btn" (click)="removeItem(item.id)">×</button>
             </div>
           </div>

--- a/src/app/components/pages/checkout/checkout.component.ts
+++ b/src/app/components/pages/checkout/checkout.component.ts
@@ -79,9 +79,25 @@ export class CheckoutComponent implements OnInit {
   getTotal(): number {
     return this.cartService.getTotal();
   }
-
   removeItem(itemId: string) {
     this.cartService.removeFromCart(itemId);
+  }
+
+  updateQuantity(itemId: string, quantity: number) {
+    this.cartService.updateQuantity(itemId, quantity);
+  }
+
+  increaseQuantity(item: CartItem) {
+    this.cartService.updateQuantity(item.id, (item.quantity || 1) + 1);
+  }
+
+  decreaseQuantity(item: CartItem) {
+    const currentQuantity = item.quantity || 1;
+    if (currentQuantity > 1) {
+      this.cartService.updateQuantity(item.id, currentQuantity - 1);
+    } else {
+      this.removeItem(item.id);
+    }
   }
   onSubmit() {
     if (this.checkoutForm.valid) {

--- a/src/app/components/sections/mini-basket/mini-basket.component.css
+++ b/src/app/components/sections/mini-basket/mini-basket.component.css
@@ -1,0 +1,266 @@
+.mini-basket {
+  position: fixed;
+  top: 20px;
+  right: 20px;
+  width: 350px;
+  max-width: 90vw;
+  background: #1a1a1a;
+  border: 1px solid #333;
+  border-radius: 12px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.5);
+  z-index: 1000;
+  transform: translateX(120%);
+  opacity: 0;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  overflow: hidden;
+}
+
+.mini-basket.visible {
+  transform: translateX(0);
+  opacity: 1;
+}
+
+.mini-basket-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 16px 20px;
+  background: #ff4757;
+  color: white;
+  border-bottom: 1px solid #333;
+}
+
+.mini-basket-header h3 {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.close-btn {
+  background: none;
+  border: none;
+  color: white;
+  font-size: 24px;
+  cursor: pointer;
+  padding: 0;
+  width: 30px;
+  height: 30px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  transition: background-color 0.2s ease;
+}
+
+.close-btn:hover {
+  background-color: rgba(255, 255, 255, 0.2);
+}
+
+.mini-basket-content {
+  padding: 20px;
+  color: #e0e0e0;
+}
+
+.cart-summary {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 16px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid #333;
+}
+
+.item-count {
+  font-size: 14px;
+  color: #a0a0a0;
+}
+
+.total-price {
+  font-size: 18px;
+  font-weight: 600;
+  color: #ff4757;
+}
+
+.cart-items {
+  max-height: 200px;
+  overflow-y: auto;
+  margin-bottom: 16px;
+}
+
+.cart-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 0;
+  border-bottom: 1px solid #2a2a2a;
+}
+
+.cart-item:last-child {
+  border-bottom: none;
+}
+
+.item-info {
+  flex: 1;
+  margin-right: 12px;
+}
+
+.item-title {
+  font-size: 14px;
+  font-weight: 600;
+  margin-bottom: 4px;
+  color: #ffffff;
+}
+
+.item-package {
+  font-size: 12px;
+  color: #a0a0a0;
+  margin-bottom: 4px;
+}
+
+.item-price {
+  font-size: 14px;
+  color: #ff4757;
+  font-weight: 600;
+}
+
+.quantity-controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.qty-btn {
+  width: 28px;
+  height: 28px;
+  border: 1px solid #444;
+  background: #333;
+  color: #fff;
+  border-radius: 4px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 16px;
+  font-weight: 600;
+  transition: all 0.2s ease;
+}
+
+.qty-btn:hover {
+  background: #444;
+  border-color: #555;
+}
+
+.qty-btn.minus:hover {
+  background: #ff4757;
+  border-color: #ff4757;
+}
+
+.qty-btn.plus:hover {
+  background: #2ed573;
+  border-color: #2ed573;
+}
+
+.quantity {
+  font-size: 14px;
+  font-weight: 600;
+  min-width: 20px;
+  text-align: center;
+}
+
+.more-items {
+  text-align: center;
+  padding: 8px 0;
+  font-size: 12px;
+  color: #a0a0a0;
+  font-style: italic;
+}
+
+.mini-basket-actions {
+  display: flex;
+  gap: 12px;
+  flex-direction: column;
+}
+
+.continue-btn,
+.checkout-btn {
+  padding: 12px 16px;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 600;
+  transition: all 0.2s ease;
+}
+
+.continue-btn {
+  background: transparent;
+  color: #a0a0a0;
+  border: 1px solid #444;
+}
+
+.continue-btn:hover {
+  background: #333;
+  color: #fff;
+}
+
+.checkout-btn {
+  background: #ff4757;
+  color: white;
+}
+
+.checkout-btn:hover {
+  background: #ff3742;
+  transform: translateY(-1px);
+}
+
+/* Custom scrollbar for cart items */
+.cart-items::-webkit-scrollbar {
+  width: 6px;
+}
+
+.cart-items::-webkit-scrollbar-track {
+  background: #1a1a1a;
+}
+
+.cart-items::-webkit-scrollbar-thumb {
+  background: #444;
+  border-radius: 3px;
+}
+
+.cart-items::-webkit-scrollbar-thumb:hover {
+  background: #555;
+}
+
+/* Mobile responsiveness */
+@media (max-width: 768px) {
+  .mini-basket {
+    top: 10px;
+    right: 10px;
+    width: calc(100vw - 20px);
+    max-width: 350px;
+  }
+  
+  .mini-basket-header {
+    padding: 12px 16px;
+  }
+  
+  .mini-basket-content {
+    padding: 16px;
+  }
+}
+
+/* Animation for item addition */
+@keyframes slideInRight {
+  from {
+    transform: translateX(100%);
+    opacity: 0;
+  }
+  to {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+
+.mini-basket.visible {
+  animation: slideInRight 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}

--- a/src/app/components/sections/mini-basket/mini-basket.component.html
+++ b/src/app/components/sections/mini-basket/mini-basket.component.html
@@ -1,0 +1,38 @@
+<div class="mini-basket" [class.visible]="isVisible && cartItems.length > 0">
+  <div class="mini-basket-header">
+    <h3>🛒 Item Added to Basket!</h3>
+    <button class="close-btn" (click)="hideMiniBasket()">×</button>
+  </div>
+  
+  <div class="mini-basket-content">
+    <div class="cart-summary">
+      <span class="item-count">{{getTotalItems()}} item(s)</span>
+      <span class="total-price">${{getTotalPrice().toFixed(2)}}</span>
+    </div>
+    
+    <div class="cart-items" *ngIf="cartItems.length > 0">
+      <div class="cart-item" *ngFor="let item of cartItems.slice(-3); trackBy: trackByItem">
+        <div class="item-info">
+          <div class="item-title">{{item.title}}</div>
+          <div class="item-package">{{item.package}}</div>
+          <div class="item-price">${{item.price.toFixed(2)}}</div>
+        </div>
+        
+        <div class="quantity-controls">
+          <button class="qty-btn minus" (click)="decreaseQuantity(item)">-</button>
+          <span class="quantity">{{item.quantity || 1}}</span>
+          <button class="qty-btn plus" (click)="increaseQuantity(item)">+</button>
+        </div>
+      </div>
+      
+      <div class="more-items" *ngIf="cartItems.length > 3">
+        <span>+ {{cartItems.length - 3}} more item(s)</span>
+      </div>
+    </div>
+    
+    <div class="mini-basket-actions">
+      <button class="continue-btn" (click)="continueShopping()">Continue Shopping</button>
+      <button class="checkout-btn" (click)="goToCheckout()">View Cart & Checkout</button>
+    </div>
+  </div>
+</div>

--- a/src/app/components/sections/mini-basket/mini-basket.component.ts
+++ b/src/app/components/sections/mini-basket/mini-basket.component.ts
@@ -1,0 +1,101 @@
+import { Component, OnInit, OnDestroy, inject, ChangeDetectionStrategy, ChangeDetectorRef } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Router } from '@angular/router';
+import { CartService, CartItem } from '../../../services/cart.service';
+import { Subscription } from 'rxjs';
+
+@Component({
+  selector: 'app-mini-basket',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './mini-basket.component.html',
+  styleUrl: './mini-basket.component.css',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class MiniBasketComponent implements OnInit, OnDestroy {  cartService = inject(CartService);
+  router = inject(Router);
+  cdr = inject(ChangeDetectorRef);
+    cartItems: CartItem[] = [];
+  isVisible = false;
+  autoHideTimeout?: number;
+  private cartSubscription?: Subscription;
+  private itemAddedSubscription?: Subscription;
+
+  ngOnInit() {    // Listen to cart changes
+    this.cartSubscription = this.cartService.cartItems$.subscribe(items => {
+      this.cartItems = items;
+      this.cdr.markForCheck(); // Manually trigger change detection
+    });
+    
+    // Listen to item additions to show mini basket
+    this.itemAddedSubscription = this.cartService.itemAdded$.subscribe(() => {
+      this.showMiniBasket();
+      this.cdr.markForCheck(); // Manually trigger change detection
+    });
+  }
+
+  ngOnDestroy() {
+    this.cartSubscription?.unsubscribe();
+    this.itemAddedSubscription?.unsubscribe();
+    if (this.autoHideTimeout) {
+      clearTimeout(this.autoHideTimeout);
+    }
+  }
+
+  showMiniBasket() {
+    this.isVisible = true;
+    
+    // Auto-hide after 5 seconds
+    if (this.autoHideTimeout) {
+      clearTimeout(this.autoHideTimeout);
+    }
+    
+    this.autoHideTimeout = window.setTimeout(() => {
+      this.hideMiniBasket();
+    }, 5000);
+  }
+
+  hideMiniBasket() {
+    this.isVisible = false;
+    if (this.autoHideTimeout) {
+      clearTimeout(this.autoHideTimeout);
+    }
+  }
+
+  increaseQuantity(item: CartItem) {
+    this.cartService.updateQuantity(item.id, (item.quantity || 1) + 1);
+  }
+
+  decreaseQuantity(item: CartItem) {
+    const currentQuantity = item.quantity || 1;
+    if (currentQuantity > 1) {
+      this.cartService.updateQuantity(item.id, currentQuantity - 1);
+    } else {
+      this.removeItem(item.id);
+    }
+  }
+
+  removeItem(itemId: string) {
+    this.cartService.removeFromCart(itemId);
+  }
+
+  getTotalPrice(): number {
+    return this.cartService.getTotal();
+  }
+
+  getTotalItems(): number {
+    return this.cartService.getItemCount();
+  }
+
+  goToCheckout() {
+    this.hideMiniBasket();
+    this.router.navigate(['/checkout']);
+  }
+  continueShopping() {
+    this.hideMiniBasket();
+  }
+
+  trackByItem(index: number, item: CartItem): string {
+    return item.id;
+  }
+}


### PR DESCRIPTION
- Display a fixed-position mini basket in the top-right when clicking “Add to Basket and Continue”
- Read and write basket data from/to local storage (same keys as Checkout page)
- Show concise summary of selected services (name, quantity, subtotal) and overall total
- Add “+” and “–” buttons for adjusting quantities directly in the mini basket
- Remove items when quantity reaches zero; keep Checkout page in sync via local storage updates