### PR TITLE
Add “Thank You” page with order summary and redirect post-checkout

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -13,10 +13,13 @@ export const routes: Routes = [
   { 
     path: 'services', 
     loadComponent: () => import('./components/pages/my-services/my-services.component').then(c => c.MyServicesComponent) 
-  },
-  { 
+  },  { 
     path: 'checkout', 
     loadComponent: () => import('./components/pages/checkout/checkout.component').then(c => c.CheckoutComponent) 
+  },
+  { 
+    path: 'thank-you', 
+    loadComponent: () => import('./components/pages/thank-you/thank-you.component').then(c => c.ThankYouComponent) 
   },
   { path: '**', redirectTo: '/home' }
 ];

--- a/src/app/components/pages/thank-you/thank-you.component.css
+++ b/src/app/components/pages/thank-you/thank-you.component.css
@@ -1,0 +1,496 @@
+.thank-you-container {
+  min-height: 100vh;
+  background: linear-gradient(135deg, #292929 0%, #2e2e2e 100%);
+  padding: 0;
+}
+
+.thank-you-content {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: calc(100vh - 80px);
+  padding: 2rem 1rem;
+}
+
+.status-card {
+  background: white;
+  border-radius: 20px;
+  padding: 3rem 2rem;
+  max-width: 600px;
+  width: 100%;
+  text-align: center;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.1);
+  border: 3px solid;
+  animation: slideInUp 0.6s ease-out;
+}
+
+.status-card.status-approved {
+  border-color: #10b981;
+  background: linear-gradient(145deg, #ffffff 0%, #f0fdf4 100%);
+}
+
+.status-card.status-declined {
+  border-color: #ef4444;
+  background: linear-gradient(145deg, #ffffff 0%, #fef2f2 100%);
+}
+
+.status-card.status-failed {
+  border-color: #f59e0b;
+  background: linear-gradient(145deg, #ffffff 0%, #fffbeb 100%);
+}
+
+.status-icon {
+  font-size: 4rem;
+  margin-bottom: 1rem;
+  animation: bounceIn 0.8s ease-out 0.3s both;
+}
+
+.status-title {
+  font-size: 2.5rem;
+  font-weight: bold;
+  margin-bottom: 1rem;
+  color: #1f2937;
+}
+
+.status-approved .status-title {
+  color: #059669;
+}
+
+.status-declined .status-title {
+  color: #dc2626;
+}
+
+.status-failed .status-title {
+  color: #d97706;
+}
+
+.status-message {
+  font-size: 1.1rem;
+  color: #6b7280;
+  margin-bottom: 2rem;
+  line-height: 1.6;
+}
+
+.order-details {
+  background: #f9fafb;
+  border-radius: 12px;
+  padding: 1.5rem;
+  margin-bottom: 2rem;
+  border-left: 4px solid #10b981;
+}
+
+.order-items {
+  background: #f8fafc;
+  border-radius: 12px;
+  padding: 1.5rem;
+  margin-bottom: 2rem;
+  border: 1px solid #e2e8f0;
+}
+
+.order-items h3 {
+  color: #1f2937;
+  margin-bottom: 1rem;
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.items-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.75rem;
+  background: white;
+  border-radius: 8px;
+  border: 1px solid #e5e7eb;
+}
+
+.item-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.item-name {
+  font-weight: 600;
+  color: #374151;
+}
+
+.item-quantity {
+  font-size: 0.875rem;
+  color: #6b7280;
+}
+
+.item-price {
+  font-weight: 600;
+  color: #059669;
+  font-family: monospace;
+}
+
+.detail-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+
+.detail-row:last-child {
+  margin-bottom: 0;
+}
+
+.label {
+  font-weight: 600;
+  color: #374151;
+}
+
+.value {
+  color: #1f2937;
+  font-family: monospace;
+}
+
+.order-status-info {
+  text-align: left;
+  margin-bottom: 2rem;
+}
+
+.info-section h3 {
+  color: #1f2937;
+  margin-bottom: 1rem;
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.info-section ul {
+  list-style: none;
+  padding: 0;
+  margin-bottom: 1rem;
+}
+
+.info-section li {
+  padding: 0.5rem 0;
+  color: #4b5563;
+  display: flex;
+  align-items: center;
+}
+
+.approved-info li {
+  color: #059669;
+}
+
+.declined-info li {
+  color: #dc2626;
+}
+
+.failed-info li {
+  color: #d97706;
+}
+
+.suggestion {
+  background: #f3f4f6;
+  padding: 1rem;
+  border-radius: 8px;
+  color: #374151;
+  font-style: italic;
+  margin-top: 1rem;
+}
+
+.action-buttons {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  margin-bottom: 2rem;
+  flex-wrap: wrap;
+}
+
+.primary-btn, .secondary-btn {
+  padding: 0.875rem 2rem;
+  border-radius: 12px;
+  font-weight: 600;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  border: none;
+  min-width: 140px;
+}
+
+.primary-btn {
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  color: white;
+}
+
+.primary-btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 20px rgba(102, 126, 234, 0.4);
+}
+
+.secondary-btn {
+  background: white;
+  color: #6b7280;
+  border: 2px solid #e5e7eb;
+}
+
+.secondary-btn:hover {
+  background: #f9fafb;
+  color: #374151;
+  transform: translateY(-1px);
+}
+
+.support-section {
+  border-top: 1px solid #e5e7eb;
+  padding-top: 1.5rem;
+  color: #6b7280;
+}
+
+.support-section h4 {
+  color: #374151;
+  margin-bottom: 0.5rem;
+}
+
+.support-contacts {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.support-contacts span {
+  font-family: monospace;
+  background: #f3f4f6;
+  padding: 0.5rem;
+  border-radius: 6px;
+  display: inline-block;
+}
+
+.error-message {
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  border-radius: 8px;
+  padding: 1rem;
+  margin-bottom: 1.5rem;
+  color: #991b1b;
+}
+
+.error-message strong {
+  color: #7f1d1d;
+}
+
+.error-code {
+  font-family: monospace;
+  font-size: 0.9rem;
+  margin-top: 0.5rem;
+  opacity: 0.8;
+}
+
+.failed-error-message {
+  background: #fef2f2;
+  border: 2px solid #dc2626;
+  border-radius: 8px;
+  padding: 1rem;
+  margin: 1rem 0;
+  text-align: center;
+}
+
+.error-highlight {
+  font-size: 1.1rem;
+  font-weight: bold;
+  color: #dc2626;
+  margin-bottom: 0.5rem;
+}
+
+.declined-info h4 {
+  color: #dc2626;
+  margin-top: 1.5rem;
+  margin-bottom: 0.75rem;
+  font-weight: 600;
+}
+
+.debug-info {
+  background: #f3f4f6;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  padding: 0.75rem;
+  margin-bottom: 1rem;
+  font-family: monospace;
+  font-size: 0.8rem;
+}
+
+.debug-info p {
+  margin: 0.25rem 0;
+  color: #374151;
+}
+
+/* Next Steps Section - Styling for approved transactions */
+.next-steps-container {
+  animation: fadeInUp 0.6s ease-out 0.5s both;
+}
+
+.next-steps-title {
+  color: #059669;
+  font-weight: 600;
+  margin-bottom: 1rem;
+  font-size: 1.25rem;
+  display: flex;
+  align-items: center;
+}
+
+.next-steps-title::before {
+  content: "🎉";
+  margin-right: 0.5rem;
+  font-size: 1.1rem;
+}
+
+.next-steps-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.next-steps-list li {
+  padding: 0.75rem 0;
+  color: #059669;
+  display: flex;
+  align-items: center;
+  position: relative;
+  opacity: 0;
+  animation: fadeInSlide 0.5s ease-out forwards;
+}
+
+.next-steps-list li:nth-child(1) { animation-delay: 0.7s; }
+.next-steps-list li:nth-child(2) { animation-delay: 0.9s; }
+.next-steps-list li:nth-child(3) { animation-delay: 1.1s; }
+.next-steps-list li:nth-child(4) { animation-delay: 1.3s; }
+
+/* Next Steps Container */
+.next-steps-container {
+  background: linear-gradient(145deg, #f0fdf4 0%, #ecfdf5 100%);
+  border: 1px solid #bbf7d0;
+  border-radius: 12px;
+  padding: 1.5rem;
+  margin-bottom: 1rem;
+}
+
+.approved-fallback {
+  background: linear-gradient(145deg, #fffbeb 0%, #fef3c7 100%);
+  border: 1px solid #fde68a;
+  border-radius: 12px;
+  padding: 1.5rem;
+  text-align: center;
+}
+
+.approved-fallback h3 {
+  color: #d97706;
+  margin-bottom: 0.75rem;
+}
+
+.approved-fallback p {
+  color: #92400e;
+  margin: 0;
+}
+
+@keyframes slideInUp {
+  from {
+    opacity: 0;
+    transform: translateY(50px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes bounceIn {
+  0% {
+    opacity: 0;
+    transform: scale(0.3);
+  }
+  50% {
+    opacity: 1;
+    transform: scale(1.1);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@keyframes fadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(30px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes fadeInSlide {
+  from {
+    opacity: 0;
+    transform: translateX(-20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@media (max-width: 768px) {
+  .thank-you-content {
+    padding: 1rem;
+  }
+
+  .status-card {
+    padding: 2rem 1.5rem;
+  }
+
+  .status-icon {
+    font-size: 3rem;
+  }
+
+  .status-title {
+    font-size: 2rem;
+  }
+
+  .action-buttons {
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .primary-btn, .secondary-btn {
+    width: 100%;
+    max-width: 280px;
+  }
+  .detail-row {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.25rem;
+  }
+
+  .item {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
+  }
+
+  .item-info {
+    width: 100%;
+  }
+
+  .item-price {
+    align-self: flex-end;
+  }
+
+  .support-contacts {
+    gap: 0.75rem;
+  }
+
+  .support-contacts span {
+    font-size: 0.9rem;
+  }
+}

--- a/src/app/components/pages/thank-you/thank-you.component.html
+++ b/src/app/components/pages/thank-you/thank-you.component.html
@@ -1,0 +1,131 @@
+<div class="thank-you-container">
+  <app-header></app-header>
+  
+  <div class="thank-you-content">
+    <div class="status-card" [ngClass]="getStatusClass()">
+      <div class="status-icon">
+        {{ getStatusIcon() }}
+      </div>
+      
+      <h1 class="status-title">{{ getStatusTitle() }}</h1>
+      
+      <p class="status-message">{{ getStatusMessage() }}</p>      <!-- Show actual error message from response -->
+     
+
+      <!-- Debug info (can be removed in production) -->
+      <div class="debug-info" *ngIf="orderData">
+        <p><small><strong>Server Status:</strong> {{ getServerResponseStatus() }}</small></p>
+        <p><small><strong>Is Declined:</strong> {{ isServerStatusDeclined() ? 'Yes' : 'No' }}</small></p>
+        <p><small><strong>Display Status:</strong> {{ orderStatus }}</small></p>
+      </div>
+        <div class="order-details" *ngIf="orderStatus === 'approved'">
+        <div class="detail-row">
+          <span class="label">Order ID:</span>
+          <span class="value">#{{ orderId }}</span>
+        </div>
+        <div class="detail-row" *ngIf="customerName">
+          <span class="label">Customer:</span>
+          <span class="value">{{ customerName }}</span>
+        </div>
+        <div class="detail-row" *ngIf="email">
+          <span class="label">Email:</span>
+          <span class="value">{{ email }}</span>
+        </div>
+        <div class="detail-row" *ngIf="orderDate">
+          <span class="label">Order Date:</span>
+          <span class="value">{{ orderDate }}</span>
+        </div>
+        <div class="detail-row" *ngIf="orderTotal > 0">
+          <span class="label">Total Amount:</span>
+          <span class="value">${{ orderTotal.toFixed(2) }}</span>
+        </div>
+        <div class="detail-row" *ngIf="orderItems.length > 0">
+          <span class="label">Items:</span>
+          <span class="value">{{ orderItems.length }} service(s)</span>
+        </div>
+      </div>
+
+      <!-- Order Items Summary -->
+      <div class="order-items" *ngIf="orderStatus === 'approved' && orderItems.length > 0">
+        <h3>Order Summary</h3>
+        <div class="items-list">
+          <div class="item" *ngFor="let item of orderItems">
+            <div class="item-info">
+              <span class="item-name">{{ item.name || item.title }}</span>
+              <span class="item-quantity">Qty: {{ item.quantity || 1 }}</span>
+            </div>
+            <span class="item-price">${{ (item.price * (item.quantity || 1)).toFixed(2) }}</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="order-status-info">        <div class="info-section" [ngSwitch]="orderStatus">          <!-- Approved Status -->
+          <div *ngSwitchCase="'approved'" class="approved-info">
+            <!-- What happens next section - only for successful approved transactions -->
+            <div *ngIf="shouldShowNextSteps()" class="next-steps-container">
+              <h3 class="next-steps-title">What happens next?</h3>
+              <ul class="next-steps-list">
+                <li>✓ You will receive a confirmation email shortly</li>
+                <li>✓ Our team will contact you within 24 hours</li>
+                <li>✓ We'll schedule your service at your convenience</li>
+                <li>✓ Track your order status in your email</li>
+              </ul>
+            </div>
+            
+            <!-- Fallback message for approved but unsuccessful transactions -->
+            <div *ngIf="!shouldShowNextSteps()" class="approved-fallback">
+              <h3>Order Received</h3>
+              <p>Your order has been received but may require additional verification. We'll contact you shortly with updates.</p>
+            </div>
+          </div><!-- Declined Status -->
+          <div *ngSwitchCase="'declined'" class="declined-info">
+            <h3>Payment Failed - Order Declined</h3>
+            <div class="failed-error-message">
+              <p class="error-highlight">❌ Transaction Failed</p>
+              <p>Your payment was declined by the payment processor.</p>
+            </div>
+            <h4>Common reasons for declined payments:</h4>
+            <ul>
+              <li>• Payment method was declined by your bank</li>
+              <li>• Insufficient funds or credit limit reached</li>
+              <li>• Card details may be incorrect or expired</li>
+              <li>• Security concerns flagged by payment processor</li>
+              <li>• Card blocked for online transactions</li>
+            </ul>
+            <p class="suggestion">Please check your payment information and try again, or use a different payment method.</p>
+          </div>
+
+          <!-- Failed Status -->
+          <div *ngSwitchCase="'failed'" class="failed-info">
+            <h3>Technical Issue Occurred</h3>
+            <ul>
+              <li>• Connection timeout during processing</li>
+              <li>• Server temporarily unavailable</li>
+              <li>• Payment gateway error</li>
+              <li>• System maintenance in progress</li>
+            </ul>
+            <p class="suggestion">Please try again in a few minutes. If the problem persists, contact our support team.</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="action-buttons">
+        <button class="primary-btn" (click)="onActionClick()">
+          {{ getActionText() }}
+        </button>
+        <button class="secondary-btn" (click)="goHome()">
+          Back to Home
+        </button>
+      </div>
+
+      <div class="support-section" *ngIf="orderStatus !== 'approved'">
+        <h4>Need Help?</h4>
+        <p>Contact our support team:</p>
+        <div class="support-contacts">
+          <!-- <span>📧 support@esalesone.com</span> -->
+          <span>📞 1-800-ESALES-1</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/app/components/pages/thank-you/thank-you.component.spec.ts
+++ b/src/app/components/pages/thank-you/thank-you.component.spec.ts
@@ -1,0 +1,146 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, Router } from '@angular/router';
+import { of } from 'rxjs';
+
+import { ThankYouComponent } from './thank-you.component';
+import { OrderService, OrderData } from '../../../services/order.service';
+
+describe('ThankYouComponent', () => {
+  let component: ThankYouComponent;
+  let fixture: ComponentFixture<ThankYouComponent>;
+  let mockOrderService: jasmine.SpyObj<OrderService>;
+  let mockRouter: jasmine.SpyObj<Router>;
+  let mockActivatedRoute: jasmine.SpyObj<ActivatedRoute>;
+
+  beforeEach(async () => {
+    const orderServiceSpy = jasmine.createSpyObj('OrderService', ['getOrderData', 'getOrderStatus', 'getOrderId', 'clearOrderData']);
+    const routerSpy = jasmine.createSpyObj('Router', ['navigate']);
+    const activatedRouteSpy = jasmine.createSpyObj('ActivatedRoute', [], {
+      queryParams: of({})
+    });
+
+    await TestBed.configureTestingModule({
+      imports: [ThankYouComponent],
+      providers: [
+        { provide: OrderService, useValue: orderServiceSpy },
+        { provide: Router, useValue: routerSpy },
+        { provide: ActivatedRoute, useValue: activatedRouteSpy }
+      ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(ThankYouComponent);
+    component = fixture.componentInstance;
+    mockOrderService = TestBed.inject(OrderService) as jasmine.SpyObj<OrderService>;
+    mockRouter = TestBed.inject(Router) as jasmine.SpyObj<Router>;
+    mockActivatedRoute = TestBed.inject(ActivatedRoute) as jasmine.SpyObj<ActivatedRoute>;
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+  it('should show next steps only for approved successful transactions', () => {
+    const approvedOrderData: OrderData = {
+      response: {
+        id: 'ORD-12345',
+        status: 'APPROVED'
+      },
+      customerInfo: {
+        fullName: 'John Doe',
+        email: 'john@example.com',
+        phone: '123-456-7890',
+        address: '123 Main St',
+        city: 'Anytown',
+        state: 'ST',
+        zipCode: '12345'
+      },
+      orderSummary: {
+        items: [],
+        total: 100,
+        itemCount: 1
+      },
+      timestamp: Date.now()
+    };
+
+    mockOrderService.getOrderData.and.returnValue(approvedOrderData);
+    mockOrderService.getOrderStatus.and.returnValue('approved');
+    mockOrderService.getOrderId.and.returnValue('ORD-12345');
+
+    component.ngOnInit();
+    fixture.detectChanges();
+
+    expect(component.shouldShowNextSteps()).toBe(true);
+    expect(component.orderStatus).toBe('approved');
+  });
+
+  it('should NOT show next steps for declined transactions', () => {
+    const declinedOrderData: OrderData = {
+      response: {
+        id: 'ORD-12345',
+        message: 'Payment declined',
+        success: false,
+        status: 'DECLINED'
+      },
+      customerInfo: {
+        fullName: 'John Doe',
+        email: 'john@example.com',
+        phone: '123-456-7890',
+        address: '123 Main St',
+        city: 'Anytown',
+        state: 'ST',
+        zipCode: '12345'
+      },
+      orderSummary: {
+        items: [],
+        total: 100,
+        itemCount: 1
+      },
+      timestamp: Date.now()
+    };
+
+    mockOrderService.getOrderData.and.returnValue(declinedOrderData);
+    mockOrderService.getOrderStatus.and.returnValue('declined');
+    mockOrderService.getOrderId.and.returnValue('ORD-12345');
+
+    component.ngOnInit();
+    fixture.detectChanges();
+
+    expect(component.shouldShowNextSteps()).toBe(false);
+    expect(component.orderStatus).toBe('declined');
+  });
+  it('should NOT show next steps for approved but unsuccessful transactions', () => {
+    const approvedButUnsuccessfulOrderData: OrderData = {
+      response: {
+        id: 'ORD-12345',
+        message: 'Order needs verification',
+        success: false,
+        status: 'APPROVED'
+      },
+      customerInfo: {
+        fullName: 'John Doe',
+        email: 'john@example.com',
+        phone: '123-456-7890',
+        address: '123 Main St',
+        city: 'Anytown',
+        state: 'ST',
+        zipCode: '12345'
+      },
+      orderSummary: {
+        items: [],
+        total: 100,
+        itemCount: 1
+      },
+      timestamp: Date.now()
+    };
+
+    mockOrderService.getOrderData.and.returnValue(approvedButUnsuccessfulOrderData);
+    mockOrderService.getOrderStatus.and.returnValue('approved');
+    mockOrderService.getOrderId.and.returnValue('ORD-12345');
+
+    component.ngOnInit();
+    fixture.detectChanges();
+
+    expect(component.shouldShowNextSteps()).toBe(false);
+    expect(component.orderStatus).toBe('approved');
+  });
+});

--- a/src/app/components/pages/thank-you/thank-you.component.ts
+++ b/src/app/components/pages/thank-you/thank-you.component.ts
@@ -1,0 +1,202 @@
+import { Component, OnInit, OnDestroy, inject, Inject, PLATFORM_ID } from '@angular/core';
+import { CommonModule, isPlatformBrowser } from '@angular/common';
+import { ActivatedRoute, Router } from '@angular/router';
+import { HeaderComponent } from '../../sections/header/header.component';
+import { OrderService, OrderData } from '../../../services/order.service';
+
+export type OrderStatus = 'approved' | 'declined' | 'failed';
+
+@Component({
+  selector: 'app-thank-you',
+  imports: [CommonModule, HeaderComponent],
+  templateUrl: './thank-you.component.html',
+  styleUrl: './thank-you.component.css'
+})
+export class ThankYouComponent implements OnInit, OnDestroy {
+  orderStatus: OrderStatus = 'approved';
+  orderId: string = '';
+  customerName: string = '';
+  email: string = '';
+  orderData: OrderData | null = null;
+  orderTotal: number = 0;
+  orderItems: any[] = [];
+  orderDate: string = '';
+
+  private route = inject(ActivatedRoute);
+  private router = inject(Router);
+  private orderService = inject(OrderService);
+
+  constructor(@Inject(PLATFORM_ID) private platformId: Object) {}
+  ngOnInit() {
+    this.scrollToTop();
+    this.loadOrderData();
+  }
+
+  private scrollToTop() {
+    if (isPlatformBrowser(this.platformId)) {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    }
+  }
+
+  private loadOrderData() {
+    // First try to get order data from service
+    this.orderData = this.orderService.getOrderData();
+    
+    if (this.orderData) {
+      // Load data from order service
+      this.orderStatus = this.orderService.getOrderStatus() || 'approved';
+      this.orderId = this.orderService.getOrderId();
+      this.customerName = this.orderData.customerInfo.fullName;
+      this.email = this.orderData.customerInfo.email;
+      this.orderTotal = this.orderData.orderSummary.total;
+      this.orderItems = this.orderData.orderSummary.items;
+      this.orderDate = new Date(this.orderData.timestamp).toLocaleDateString();
+    } else {
+      // Fallback to query parameters for backward compatibility
+      this.getOrderDetailsFromQueryParams();
+    }
+  }
+
+  private getOrderDetailsFromQueryParams() {
+    this.route.queryParams.subscribe(params => {
+      this.orderStatus = params['status'] || 'approved';
+      this.orderId = params['orderId'] || this.generateOrderId();
+      this.customerName = params['customerName'] || '';
+      this.email = params['email'] || '';
+      this.orderDate = new Date().toLocaleDateString();
+    });
+  }
+
+  private generateOrderId(): string {
+    return 'ORD-' + Date.now().toString().slice(-8);
+  }
+
+  getStatusIcon(): string {
+    switch (this.orderStatus) {
+      case 'approved':
+        return '✅';
+      case 'declined':
+        return '❌';
+      case 'failed':
+        return '⚠️';
+      default:
+        return '✅';
+    }
+  }
+
+  getStatusClass(): string {
+    switch (this.orderStatus) {
+      case 'approved':
+        return 'status-approved';
+      case 'declined':
+        return 'status-declined';
+      case 'failed':
+        return 'status-failed';
+      default:
+        return 'status-approved';
+    }
+  }
+
+  getStatusTitle(): string {
+    switch (this.orderStatus) {
+      case 'approved':
+        return 'Order Confirmed!';
+      case 'declined':
+        return 'Order Declined';
+      case 'failed':
+        return 'Order Failed';
+      default:
+        return 'Order Confirmed!';
+    }
+  }
+  getStatusMessage(): string {
+    switch (this.orderStatus) {
+      case 'approved':
+        return 'Thank you for your order! Your transaction has been successfully processed.';
+      case 'declined':
+        return 'Unfortunately, your payment has been declined. Please check your payment details and try again.';
+      case 'failed':
+        return 'There was an issue processing your order. Please try again or contact support.';
+      default:
+        return 'Thank you for your order!';
+    }
+  }
+
+  getActionText(): string {
+    switch (this.orderStatus) {
+      case 'approved':
+        return 'Continue Shopping';
+      case 'declined':
+      case 'failed':
+        return 'Try Again';
+      default:
+        return 'Continue Shopping';
+    }
+  }
+
+  onActionClick() {
+    switch (this.orderStatus) {
+      case 'approved':
+        this.router.navigate(['/services']);
+        break;
+      case 'declined':
+      case 'failed':
+        this.router.navigate(['/checkout']);
+        break;
+      default:
+        this.router.navigate(['/home']);
+    }
+  }
+  goHome() {
+    this.router.navigate(['/home']);
+  }
+  onDestroy() {
+    // Clear order data when leaving the page to prevent stale data
+    if (this.orderData) {
+      this.orderService.clearOrderData();
+    }
+  }
+
+  ngOnDestroy() {
+    this.onDestroy();
+  }
+
+  getOrderResponseMessage(): string {
+    if (this.orderData?.response?.message) {
+      return this.orderData.response.message;
+    }
+    return '';
+  }
+
+  getDetailedErrorInfo(): string {
+    if (!this.orderData || this.orderStatus === 'approved') {
+      return '';
+    }
+
+    const response = this.orderData.response;
+    if (response.error_code) {
+      return `Error Code: ${response.error_code}`;
+    }
+
+    return '';
+  }
+
+  hasOrderItems(): boolean {
+    return this.orderItems.length > 0;
+  }
+
+  getServerResponseStatus(): string {
+    if (this.orderData?.response?.status) {
+      return this.orderData.response.status.toString();
+    }
+    return 'No status received';
+  }  isServerStatusDeclined(): boolean {
+    const serverStatus = this.orderData?.response?.status?.toString().toUpperCase();
+    return serverStatus === 'DECLINED';
+  }
+
+  shouldShowNextSteps(): boolean {
+    return this.orderStatus === 'approved' && 
+           this.orderData?.response?.success !== false;
+  }
+}

--- a/src/app/services/order.service.ts
+++ b/src/app/services/order.service.ts
@@ -1,0 +1,120 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, Observable } from 'rxjs';
+import { CheckoutResponse } from './checkout.service';
+
+export interface OrderData {
+  response: CheckoutResponse;
+  customerInfo: {
+    fullName: string;
+    email: string;
+    phone: string;
+    address: string;
+    city: string;
+    state: string;
+    zipCode: string;
+  };
+  orderSummary: {
+    items: any[];
+    total: number;
+    itemCount: number;
+  };
+  timestamp: number;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class OrderService {
+  private orderDataSubject = new BehaviorSubject<OrderData | null>(null);
+  public orderData$ = this.orderDataSubject.asObservable();
+
+  constructor() {}
+
+  setOrderData(orderData: OrderData): void {
+    // Store in memory
+    this.orderDataSubject.next(orderData);
+    
+    // Also store in sessionStorage for page refresh scenarios
+    if (typeof window !== 'undefined') {
+      sessionStorage.setItem('orderData', JSON.stringify(orderData));
+    }
+  }
+
+  getOrderData(): OrderData | null {
+    // First try to get from memory
+    const memoryData = this.orderDataSubject.value;
+    if (memoryData) {
+      return memoryData;
+    }
+
+    // If not in memory, try sessionStorage
+    if (typeof window !== 'undefined') {
+      const stored = sessionStorage.getItem('orderData');
+      if (stored) {
+        try {
+          const orderData = JSON.parse(stored);
+          this.orderDataSubject.next(orderData);
+          return orderData;
+        } catch (error) {
+          console.error('Error parsing stored order data:', error);
+          this.clearOrderData();
+        }
+      }
+    }
+
+    return null;
+  }
+
+  clearOrderData(): void {
+    this.orderDataSubject.next(null);
+    if (typeof window !== 'undefined') {
+      sessionStorage.removeItem('orderData');
+    }
+  }
+  getOrderStatus(): 'approved' | 'declined' | 'failed' | null {
+    const orderData = this.getOrderData();
+    if (!orderData) return null;
+
+    // Check response status first - handle exact server status values
+    if (orderData.response.status) {
+      const serverStatus = orderData.response.status.toUpperCase();
+      
+      // Map server status to display status
+      switch (serverStatus) {
+        case 'APPROVED':
+        case 'SUCCESS':
+        case 'COMPLETED':
+          return 'approved';
+        case 'DECLINED':
+        case 'REJECTED':
+          return 'declined';
+        case 'FAILED':
+        case 'ERROR':
+        default:
+          return 'failed';
+      }
+    }
+
+    // Fallback to success/failure detection
+    if (orderData.response.success === true) {
+      return 'approved';
+    }
+
+    // Determine if declined or failed based on error message
+    const message = orderData.response.message?.toLowerCase() || '';
+    if (message.includes('declined') || message.includes('reject')) {
+      return 'declined';
+    }
+
+    return 'failed';
+  }
+
+  getOrderId(): string {
+    const orderData = this.getOrderData();
+    return orderData?.response.id || this.generateOrderId();
+  }
+
+  private generateOrderId(): string {
+    return 'ORD-' + Date.now().toString().slice(-8);
+  }
+}


### PR DESCRIPTION
Previously, after payment completion users remained on the generic confirmation screen with no clear breakdown of their purchase. This commit introduces a dedicated `/thank-you` page that displays:
- Friendly confirmation header with customer name
- Order number, date/time, and initial status
- capture `order_id`, `order_total`, and `item_count`
- Implemented CSS adjustments for responsive layout